### PR TITLE
Enable hid-multitouch for Type Cover 3 JP too.

### DIFF
--- a/kernel.spec
+++ b/kernel.spec
@@ -625,7 +625,7 @@ Patch26171: acpi-video-Add-force-native-backlight-quirk-for-Leno.patch
 Patch26175: xen-pciback-Don-t-disable-PCI_COMMAND-on-PCI-device-.patch
 
 #Surface Pro 3
-Patch9995: typecover3-multitouch.patch
+Patch9995: typecover3-multitouch-withjp.patch
 Patch9996: surface-pro-3-battery-indicator-fix.patch
 Patch9997: surface-pro-3-cameras.patch
 Patch9998: acpi-freeze-fix-sp3.patch
@@ -1371,7 +1371,7 @@ ApplyPatch acpi-video-Add-force-native-backlight-quirk-for-Leno.patch
 ApplyPatch xen-pciback-Don-t-disable-PCI_COMMAND-on-PCI-device-.patch
 
 #Surface Pro 3
-ApplyPatch typecover3-multitouch.patch
+ApplyPatch typecover3-multitouch-withjp.patch
 ApplyPatch surface-pro-3-battery-indicator-fix.patch
 ApplyPatch surface-pro-3-cameras.patch
 ApplyPatch acpi-freeze-fix-sp3.patch

--- a/typecover3-multitouch-withjp.patch
+++ b/typecover3-multitouch-withjp.patch
@@ -1,0 +1,58 @@
+diff --exclude .git -u -r a/drivers/hid/hid-core.c b/drivers/hid/hid-core.c
+--- a/drivers/hid/hid-core.c	2015-04-15 10:29:17.433826144 +0900
++++ b/drivers/hid/hid-core.c	2015-04-15 10:32:37.323251413 +0900
+@@ -704,12 +704,6 @@
+ 	    type == HID_COLLECTION_PHYSICAL)
+ 		hid->group = HID_GROUP_SENSOR_HUB;
+ 
+-	if (hid->vendor == USB_VENDOR_ID_MICROSOFT &&
+-	    (hid->product == USB_DEVICE_ID_MS_TYPE_COVER_3 ||
+-	     hid->product == USB_DEVICE_ID_MS_TYPE_COVER_3_JP) &&
+-	    hid->group == HID_GROUP_MULTITOUCH)
+-		hid->group = HID_GROUP_GENERIC;
+-
+ 	if ((parser->global.usage_page << 16) == HID_UP_GENDESK)
+ 		for (i = 0; i < parser->local.usage_index; i++)
+ 			if (parser->local.usage[i] == HID_GD_POINTER)
+@@ -1878,8 +1872,6 @@
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_DIGITAL_MEDIA_3K) },
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_WIRELESS_OPTICAL_DESKTOP_3_0) },
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_OFFICE_KB) },
+-	{ HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_TYPE_COVER_3) },
+-	{ HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_TYPE_COVER_3_JP) },
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_MONTEREY, USB_DEVICE_ID_GENIUS_KB29E) },
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_MSI, USB_DEVICE_ID_MSI_GT683R_LED_PANEL) },
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_NTRIG, USB_DEVICE_ID_NTRIG_TOUCH_SCREEN) },
+diff --exclude .git -u -r a/drivers/hid/hid-microsoft.c b/drivers/hid/hid-microsoft.c
+--- a/drivers/hid/hid-microsoft.c	2015-04-15 10:29:17.433826144 +0900
++++ b/drivers/hid/hid-microsoft.c	2015-04-15 10:32:37.323251413 +0900
+@@ -276,11 +276,6 @@
+ 		.driver_data = MS_NOGET },
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_COMFORT_MOUSE_4500),
+ 		.driver_data = MS_DUPLICATE_USAGES },
+-	{ HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_TYPE_COVER_3),
+-		.driver_data = MS_HIDINPUT },
+-	{ HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_TYPE_COVER_3_JP),
+-		.driver_data = MS_HIDINPUT },
+-
+ 	{ HID_BLUETOOTH_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_PRESENTER_8K_BT),
+ 		.driver_data = MS_PRESENTER },
+ 	{ }
+diff --exclude .git -u -r a/drivers/hid/hid-multitouch.c b/drivers/hid/hid-multitouch.c
+--- a/drivers/hid/hid-multitouch.c	2015-04-15 10:29:17.434826131 +0900
++++ b/drivers/hid/hid-multitouch.c	2015-04-15 10:32:37.324251400 +0900
+@@ -1244,6 +1244,14 @@
+ 		MT_USB_DEVICE(USB_VENDOR_ID_ILITEK,
+ 			USB_DEVICE_ID_ILITEK_MULTITOUCH) },
+ 
++	/* Microsoft Type Cover 3 */
++	{ .driver_data = MT_CLS_EXPORT_ALL_INPUTS,
++		MT_USB_DEVICE(USB_VENDOR_ID_MICROSOFT,
++			USB_DEVICE_ID_MS_TYPE_COVER_3) },
++	{ .driver_data = MT_CLS_EXPORT_ALL_INPUTS,
++		MT_USB_DEVICE(USB_VENDOR_ID_MICROSOFT,
++			USB_DEVICE_ID_MS_TYPE_COVER_3_JP) },
++
+ 	/* MosArt panels */
+ 	{ .driver_data = MT_CLS_CONFIDENCE_MINUS_ONE,
+ 		MT_USB_DEVICE(USB_VENDOR_ID_ASUS,


### PR DESCRIPTION
Hi!

This is the patch I wrote in this thread:
https://groups.google.com/forum/?hl=ja#!topic/linux-surface/qoo9_4IYLvk

This patch just does twin of USB_DEVICE_ID_MS_TYPE_COVER_3
for USB_DEVICE_ID_MS_TYPE_COVER_3_JP. 

Since the work is quite similar, I didn't make a separate _JP patch. Instead,
I combined both.

Thanks!
